### PR TITLE
Issue building with gcc 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use, for example, the AES test harness, with CAVS input, no changes need to b
 To use the test harness with ACVP input, set an environment variable 'ACVP=1' to indicate
 to the harness that you want to use the ACVP stream.
 
-ACVP=1 tests/fips_aesvs -f \<input\> \<output\>
+ACVP=1 test/fips_aesavs -f \<input\> \<output\>
 
 The reason for using environment variables is that we wanted to avoid modifying the
 OpenSSL test framework as much as possible.

--- a/fips/acvp.h
+++ b/fips/acvp.h
@@ -271,6 +271,7 @@ success:
 cJSON *read_file_as_json(char *fn)  {
     if (!fn) return NULL;
     FILE *fd = fopen (fn, "rt");
+    if (!fd) return NULL;
     cJSON *json = read_fd_as_json(fd);
     fclose (fd);
     fd = NULL;

--- a/fips/acvp.h
+++ b/fips/acvp.h
@@ -279,7 +279,8 @@ cJSON *read_file_as_json(char *fn)  {
 
 unsigned char *bin2hex(unsigned char *bin, int bin_len, unsigned char *hex, int hex_len)  {
     if (!hex || (bin_len*2+1 > hex_len)) return NULL;
-    for(int i=0, j=0; i < bin_len; i++, j+=2)
+    int i, j;
+    for(i=0, j=0; i < bin_len; i++, j+=2)
        sprintf((char *)&hex[j], "%02X", bin[i]);
     hex[bin_len*2] = '\x0';
     return hex;

--- a/fips/aes/fips_aesavs.c
+++ b/fips/aes/fips_aesavs.c
@@ -654,6 +654,7 @@ static int proc_file_acvp(char *rqfile, char *rspfile)  {
     unsigned char ciphertext[2048];
     unsigned char result_hex[2048];
     cJSON *output = NULL;
+    char *amode_src_ptr = NULL;
 
     EVP_CIPHER_CTX ctx;
     FIPS_cipher_ctx_init(&ctx);
@@ -707,7 +708,12 @@ static int proc_file_acvp(char *rqfile, char *rspfile)  {
     cJSON *algStr = NULL;
     SAFEGET(get_string_object(&algStr, vs, "algorithm"), "Algorithm identifier missing in JSON\n");
     /* Algorithm mode is last chars after last hyphen. */
-    strcpy(amode, strrchr(algStr->valuestring, '-')+1);
+    if ((amode_src_ptr = strrchr(algStr->valuestring, '-')) == NULL)
+    {
+      printf("Invalid algorithm %s\n", algStr->valuestring);
+      goto error_die;
+    }
+    strcpy(amode, amode_src_ptr+1);
 
     /* For each test group
      *      For each test case


### PR DESCRIPTION
Hi,

The file `fips/acvp.h` has variable initialization inside a `for` statement. This is only allowed since the 1999 C standard. GCC 4.8 (centos 7.5) default to -std=gnu90. Adding the flag "-std=c99" to the CC variable is not supported by `x86_64cpuid.pl`. I ended up changing your code to make it gnu90 compliant.

I propose this fix so you can support a wider range of compiler.

Cheers!
